### PR TITLE
Skip creation of markdown files for private or internal mfiles

### DIFF
--- a/+vlt/+docs/matlab2markdown.m
+++ b/+vlt/+docs/matlab2markdown.m
@@ -15,6 +15,12 @@ function out = matlab2markdown(input_path, output_path, ymlpath, objectstruct, p
 
 out = vlt.data.emptystruct('title','path','url_prefix');
 
+% Skip private, internal and +internal folders
+[~, folder_name] = fileparts(input_path);
+if any(strcmp(folder_name, {'private', 'internal', '+internal'}))
+    return
+end
+
 disp(['crawling ' input_path ' ... ']);
 
 if nargin<4,


### PR DESCRIPTION
This change will skip creation of markdown files for matlab functions or classes located in `private` or `internal` folders

**Question:**
Should folders to ignore be hardcoded, or should there be an input option to set these?